### PR TITLE
github secrets voor .env

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,6 +35,9 @@ jobs:
                   push: true
                   tags: |
                       ghcr.io/${{ github.repository }}:latest
+                  build-args: |
+                      POSTMARK_SERVER_TOKEN=${{ secrets.POSTMARK_SERVER_TOKEN }}
+                      POSTMARK_RECEIVER_EMAIL=${{ secrets.POSTMARK_RECEIVER_EMAIL }}
 
             - name: Clean up images
               run: docker system prune -f

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -1,0 +1,31 @@
+name: Build for dev
+on:
+    push:
+        branches:
+            - dev
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        permissions:
+            deployments: write
+            packages: write
+            contents: read
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
+              with:
+                  install: true
+
+            - name: Build and push Docker image
+              uses: docker/build-push-action@v6
+              with:
+                  context: .
+                  file: ./Dockerfile
+                  push: false
+
+            - name: Clean up images
+              run: docker system prune -f

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,14 @@ RUN \
 FROM base AS runner
 WORKDIR /app
 
+# Pass build arguments
+ARG POSTMARK_SERVER_TOKEN
+ARG POSTMARK_RECEIVER_EMAIL
+
+# create .env file
+RUN echo "POSTMARK_SERVER_TOKEN=$POSTMARK_SERVER_TOKEN" > .env
+RUN echo "POSTMARK_RECEIVER_EMAIL=$POSTMARK_RECEIVER_EMAIL" >> .env
+
 ENV NODE_ENV=production
 # Uncomment the following line in case you want to disable telemetry during runtime.
 # ENV NEXT_TELEMETRY_DISABLED=1

--- a/src/server/postmark.ts
+++ b/src/server/postmark.ts
@@ -1,9 +1,12 @@
 "use server";
 
 import { SignupInputs } from "@/components/form/SignupForm";
+import { connection } from "next/server";
 import * as postmark from "postmark";
 
 export async function signupEmail(values: SignupInputs) {
+    await connection();
+
     const client = new postmark.ServerClient(
         process.env.POSTMARK_SERVER_TOKEN!
     );


### PR DESCRIPTION
Ik heb met dezelfde logica als in de admin app de benodigde env variabelen uit de github secrets gehaald tijdens build en deze in een .env file geplaatst, zo heeft de server toegang tot de postmark key.